### PR TITLE
Bump version to 5.4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ list(APPEND CMAKE_MODULE_PATH
      "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 set(release-name "ome-qtwidgets")
-set(release-version "5.4.3")
+set(release-version "5.4.4")
 project("${release-name}"
         VERSION "${release-version}"
         LANGUAGES CXX)


### PR DESCRIPTION
Following the release of [OME Files 0.5.0](http://www.openmicroscopy.org/2017/12/04/ome-files-0-5-0.html), this PR increments the patch number

See also https://github.com/openmicroscopy/ome-documentation/pull/1819